### PR TITLE
Add example and support conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,21 @@ Exchange rates fetched from National Bank of Romania
 ##Instaling
 
     $ npm install bnr-rates
-    
+
 ##Simple to use
 
 ```javascript
 var bnrRates = require('bnr-rates');
 bnrRates.getRates(function(rates){
     console.log(JSON.stringify(rates,null,4));
+});
+
+bnr.convert(100, "EUR", "USD", function (err, amount, output) {
+    if (err) { return console.error(err); }
+    console.log("Result: " + amount);
+    console.log(output.input.amount + " " + output.input.currency + " are " + output.output.amount + " " + output.output.currency);
+    // => Result: 106.3789647447235
+    // => 100 EUR are 106.3789647447235 USD
 });
 ```
 

--- a/example.js
+++ b/example.js
@@ -1,0 +1,13 @@
+var bnr = require(".");
+
+bnr.getRates(function (err, rates) {
+    console.log(err || rates);
+});
+
+bnr.convert(100, "EUR", "USD", function (err, amount, output) {
+    if (err) { return console.error(err); }
+    console.log("Result: " + amount);
+    console.log(output.input.amount + " " + output.input.currency + " are " + output.output.amount + " " + output.output.currency);
+    // => Result: 106.3789647447235
+    // => 100 EUR are 106.3789647447235 USD
+});


### PR DESCRIPTION
 - Added the RON currency.
 - Send the error in the first callback argument and send the rates always in the second. Fixes #3 
 - Support for converting currencies. Fixes #2 

@aurelstocheci When you get the chance, I'd really appreciate if you can merge this and release a new version on `npm` (probably major because it contains breaking changes).